### PR TITLE
Fix: keep results | minor function call bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
       rev: 21.9b0
       hooks:
         - id: black
+          additional_dependencies: ['click==8.0.4']
     - repo: https://gitlab.com/pycqa/flake8
       rev: 3.9.2
       hooks:

--- a/xnat_admin_tools/initiate_sync.py
+++ b/xnat_admin_tools/initiate_sync.py
@@ -95,8 +95,8 @@ def sync_project(experiment_id, label_id):
         )
 
         if response.status_code == 423:
-            enqueue_sync(experiment_id)
-            return "xsync servers LOCKED"
+            enqueue_sync(experiment_id, label_id)
+            return "xsync servers LOCKED: status code {}".format(response.status_code)
         elif response.status_code == 200:
             return "xsync on {} started".format(experiment_id)
         else:
@@ -112,7 +112,7 @@ def enqueue_sync(experiment_id, label_id):
 
     redis_queue = get_redis_queue()
     job = redis_queue.enqueue(
-        sync_project, args=(experiment_id, label_id), job_timeout=600
+        sync_project, args=(experiment_id, label_id), job_timeout=600, results_ttl=-1
     )
 
     typer.echo("Job started - JOB_ID: {}".format(job.id))

--- a/xnat_admin_tools/initiate_sync.py
+++ b/xnat_admin_tools/initiate_sync.py
@@ -112,7 +112,7 @@ def enqueue_sync(experiment_id, label_id):
 
     redis_queue = get_redis_queue()
     job = redis_queue.enqueue(
-        sync_project, args=(experiment_id, label_id), job_timeout=600, results_ttl=-1
+        sync_project, args=(experiment_id, label_id), job_timeout=600, result_ttl=604800
     )
 
     typer.echo("Job started - JOB_ID: {}".format(job.id))


### PR DESCRIPTION
- Keep logs indefinitely in redis databas
- Minor bug fix while calling enque-sync
- Results are kept for 1 week inside redis DB