### PR TITLE
fix(create_new_projects.py): check xsync config for remote project id

### DIFF
--- a/xnat_admin_tools/create_new_projects.py
+++ b/xnat_admin_tools/create_new_projects.py
@@ -86,7 +86,7 @@ def set_xsync_credentials(
         response["estimatedExpirationTime"],
     )
 
-    get_url = xserver_host + f"/data/projects/{project_id}/config/xsync"
+    get_url = xrelay_host + f"/data/projects/{project_id}/config/xsync"
     R = requests.request(
         "GET",
         get_url,
@@ -94,7 +94,10 @@ def set_xsync_credentials(
         auth=basic,
     )
 
+    print("Response ", R)
+    print("get url", get_url)
     response = R.json()
+
 
     xsync_config = response["ResultSet"]["Result"][0]["contents"]
     content_dict = json.loads(xsync_config)

--- a/xnat_admin_tools/create_new_projects.py
+++ b/xnat_admin_tools/create_new_projects.py
@@ -94,8 +94,6 @@ def set_xsync_credentials(
         auth=basic,
     )
 
-    print("Response ", R)
-    print("get url", get_url)
     response = R.json()
 
     xsync_config = response["ResultSet"]["Result"][0]["contents"]

--- a/xnat_admin_tools/create_new_projects.py
+++ b/xnat_admin_tools/create_new_projects.py
@@ -93,7 +93,7 @@ def set_xsync_credentials(
         headers={"Content-Type": "application/json"},
         auth=basic,
     )
-    
+
     if R.status_code == 200:
         try:
             print(response)

--- a/xnat_admin_tools/create_new_projects.py
+++ b/xnat_admin_tools/create_new_projects.py
@@ -98,7 +98,6 @@ def set_xsync_credentials(
     print("get url", get_url)
     response = R.json()
 
-
     xsync_config = response["ResultSet"]["Result"][0]["contents"]
     content_dict = json.loads(xsync_config)
     remote_project_id = content_dict["remote_project_id"]

--- a/xnat_admin_tools/create_new_projects.py
+++ b/xnat_admin_tools/create_new_projects.py
@@ -94,25 +94,40 @@ def set_xsync_credentials(
         auth=basic,
     )
 
-    response = R.json()
+    # Project has XSync Configuration. Fetch Remote Project ID for Payload
+    if R.status_code == 200:
+        response = R.json()
+        xsync_config = response["ResultSet"]["Result"][0]["contents"]
+        content_dict = json.loads(xsync_config)
+        remote_project_id = content_dict["remote_project_id"]
 
-    xsync_config = response["ResultSet"]["Result"][0]["contents"]
-    content_dict = json.loads(xsync_config)
-    remote_project_id = content_dict["remote_project_id"]
-    # make the post call to xsync on relay
-    basic = HTTPBasicAuth(xrelay_user, xrelay_pass)
-    payload = {
-        "username": xserver_user,
-        "secret": secret,
-        "host": xserver_host,
-        "alias": alias,
-        "localProject": project_id,
-        "remoteProject": remote_project_id,
-        "estimatedExpirationTime": expiration,
-    }
+        # make the post call to xsync on relay
+        basic = HTTPBasicAuth(xrelay_user, xrelay_pass)
+        payload = {
+            "username": xserver_user,
+            "secret": secret,
+            "host": xserver_host,
+            "alias": alias,
+            "localProject": project_id,
+            "remoteProject": remote_project_id,
+            "estimatedExpirationTime": expiration,
+        }
+    # Project has no XSync Configuration. New Project. Use Project ID for Remote Project for Payload
+    else:
+        # make the post call to xsync on relay
+        basic = HTTPBasicAuth(xrelay_user, xrelay_pass)
+        payload = {
+            "username": xserver_user,
+            "secret": secret,
+            "host": xserver_host,
+            "alias": alias,
+            "localProject": project_id,
+            "remoteProject": project_id,
+            "estimatedExpirationTime": expiration,
+        }
 
     post_url = xrelay_host + "/xapi/xsync/credentials/save/projects/" + project_id
-    # print(post_url)
+
     R = requests.request(
         "POST",
         post_url,

--- a/xnat_admin_tools/create_new_projects.py
+++ b/xnat_admin_tools/create_new_projects.py
@@ -93,7 +93,16 @@ def set_xsync_credentials(
         headers={"Content-Type": "application/json"},
         auth=basic,
     )
-    response = R.json()
+    
+    if R.status_code == 200:
+        try:
+            print(response)
+            response = R.json()
+            # Process your JSON data here
+        except ValueError:
+            print("Invalid JSON")
+    else:
+        print("Error:", R.status_code, R.text)
 
     xsync_config = response["ResultSet"]["Result"][0]["contents"]
     content_dict = json.loads(xsync_config)

--- a/xnat_admin_tools/create_new_projects.py
+++ b/xnat_admin_tools/create_new_projects.py
@@ -94,15 +94,7 @@ def set_xsync_credentials(
         auth=basic,
     )
 
-    if R.status_code == 200:
-        try:
-            print(response)
-            response = R.json()
-            # Process your JSON data here
-        except ValueError:
-            print("Invalid JSON")
-    else:
-        print("Error:", R.status_code, R.text)
+    response = R.json()
 
     xsync_config = response["ResultSet"]["Result"][0]["contents"]
     content_dict = json.loads(xsync_config)

--- a/xnat_admin_tools/renew_xnat_tokens.py
+++ b/xnat_admin_tools/renew_xnat_tokens.py
@@ -30,7 +30,7 @@ def renew_xnat_tokens(
     xserver_user: str,
     xserver_pass: str,
 ):
-    projects = fetch_all_projects(xserver_host, xserver_user, xserver_pass)
+    projects = fetch_all_projects(xrelay_host, xrelay_user, xrelay_pass)
 
     for project in projects["ResultSet"]["Result"]:
         project_id = project["ID"]


### PR DESCRIPTION
# Renew XSync Tokens 

## Overview
This PR fixes the xnat-admin-tools GitHub Action for renewing tokens. Namely, `set_xsync_credentials` sets the `remote_project_id` field to the correct value defined in the project's XSync configuration file. 

## Changes
- The `fetch_all_projects` function now retrieves projects from xrelay instead of the remote xnat server.
- Added a check for the XSync configuration file. If the configuration exists, the `remote_project_id` is set to the value specified in the XSync config. (only different for ASHENAV_NRP, whose remote project ID is ASHENAV_TSS_NRP)
- For projects without an existing XSync configuration, the `remote_project_id` is set to the `project_id`. This implies that the project is yet to be initialized on the relay.  This ensures `create_new_projects()` does not break.
- Adjusted the API endpoint to `xrelay_host` for fetching the XSync configuration.

