### PR TITLE
Fix fetch latest xsync config

### DIFF
--- a/xnat_admin_tools/create_new_projects.py
+++ b/xnat_admin_tools/create_new_projects.py
@@ -101,6 +101,8 @@ def set_xsync_credentials(
     content_dict = json.loads(xsync_config)
     remote_project_id = content_dict["remote_project_id"]
 
+    print("Remote Project ID: ", remote_project_id)
+
     # make the post call to xsync on relay
     basic = HTTPBasicAuth(xrelay_user, xrelay_pass)
     payload = {

--- a/xnat_admin_tools/create_new_projects.py
+++ b/xnat_admin_tools/create_new_projects.py
@@ -96,7 +96,8 @@ def set_xsync_credentials(
 
     response = R.json()
 
-    xsync_config = response["ResultSet"]["Result"][0]["contents"]
+    # XNAT stores prior version of XSync configs. Fetching the latest (-1 index).
+    xsync_config = response["ResultSet"]["Result"][-1]["contents"]
     content_dict = json.loads(xsync_config)
     remote_project_id = content_dict["remote_project_id"]
 

--- a/xnat_admin_tools/create_new_projects.py
+++ b/xnat_admin_tools/create_new_projects.py
@@ -96,7 +96,7 @@ def set_xsync_credentials(
 
     response = R.json()
 
-    # XNAT stores prior version of XSync configs. Fetching the latest (-1 index).
+    # XNAT stores all prior versions of XSync configs per project. Fetching the latest (-1 index).
     xsync_config = response["ResultSet"]["Result"][-1]["contents"]
     content_dict = json.loads(xsync_config)
     remote_project_id = content_dict["remote_project_id"]

--- a/xnat_admin_tools/create_new_projects.py
+++ b/xnat_admin_tools/create_new_projects.py
@@ -101,8 +101,6 @@ def set_xsync_credentials(
     content_dict = json.loads(xsync_config)
     remote_project_id = content_dict["remote_project_id"]
 
-    print("Remote Project ID: ", remote_project_id)
-
     # make the post call to xsync on relay
     basic = HTTPBasicAuth(xrelay_user, xrelay_pass)
     payload = {


### PR DESCRIPTION
## Fetch Latest XSync Config

XNAT preserves all prior versions of the XSync configuration file per project.  For `ASHENHAV_NRP`, the destination project was changed to point to `ASHENHAV_TSS_NRP` at version 3.  Refactoring code to pull the latest version of the config before extracting the `remote_project_id` field. 

See `contents` dictionary in the response below:

Version 1: remote_project_id = ASHENHAV_NRP
Version 4: remote_project_id = ASHENHAV_TSS_NRP

```
"ResultSet": {
        "Result": [
            {
                "path": "json",
                "reason": "",
                "contents": "{\"project_resources\": {\"sync_type\": \"none\"}, \"subject_resources\": {\"sync_type\": \"none\"}, \"subject_assessors\": {\"sync_type\": \"none\"}, \"imaging_sessions\": {\"sync_type\": \"all\"}, \"enabled\": true, \"source_project_id\": \"ASHENHAV_NRP\", \"sync_frequency\": \"on demand\", \"sync_new_only\": true, \"identifiers\": \"use_local\", \"remote_url\": \"https://xnat.bnc.brown.edu\", \"remote_project_id\": \"ASHENHAV_NRP\", \"notification_emails\": \"\", \"customIdentifiers\": \"dateTimeLabelGenerator\", \"anonymize\": false, \"no_of_retry_days\": 3}",
                "project": "ASHENHAV_NRP",
                "unversioned": "false",
                "create_date": "2022-02-07 17:32:34.281",
                "user": "admin",
                "version": "1",
                "tool": "xsync",
                "status": "enabled"
            }, ...
            {
                "path": "json",
                "reason": "",
                "contents": "{\"project_resources\":{\"sync_type\":\"none\"},\"subject_resources\":{\"sync_type\":\"none\"},\"subject_assessors\":{\"sync_type\":\"none\"},\"imaging_sessions\":{\"sync_type\":\"all\"},\"enabled\":true,\"source_project_id\":\"ASHENHAV_NRP\",\"sync_frequency\":\"on demand\",\"sync_new_only\":true,\"identifiers\":\"use_local\",\"remote_url\":\"https://xnat.bnc.brown.edu\",\"remote_project_id\":\"ASHENHAV_TSS_NRP\",\"notification_emails\":\"\",\"customIdentifiers\":\"dateTimeLabelGenerator\",\"anonymize\":false,\"no_of_retry_days\":0}",
                "project": "ASHENHAV_NRP",
                "unversioned": "false",
                "create_date": "2023-12-15 13:55:01.592",
                "user": "admin",
                "version": "4",
                "tool": "xsync",
                "status": "enabled"
            }
        ]
    }
```